### PR TITLE
Add support for setting the expansion port supply voltage

### DIFF
--- a/OtiiTcpClient/Arc.cs
+++ b/OtiiTcpClient/Arc.cs
@@ -65,6 +65,15 @@ namespace Otii {
         }
 
         /// <summary>
+        /// Enable the expansion supply with a given voltage.
+        /// </summary>
+        /// <param name="value">Voltage to set in V. Set to 0 to disable the supply.</param>
+        public void Enable5V(double value) {
+            var request = new Enable5VWithValueRequest(DeviceId, value);
+            _client.PostRequest(request);
+        }
+
+        /// <summary>
         /// Enables the expansion port.
         /// </summary>
         /// <param name="enable">true to enable and false to disable exp port.</param>

--- a/OtiiTcpClient/TcpServerApi/ArcApi.cs
+++ b/OtiiTcpClient/TcpServerApi/ArcApi.cs
@@ -70,6 +70,24 @@ namespace Otii {
             }
         }
 
+        private class Enable5VWithValueRequest : Request {
+            public class Enable5VWithValueRequestData : ArcRequestData {
+                [JsonProperty("enable")]
+                public double Enable { get; set; }
+
+                public Enable5VWithValueRequestData(string deviceId, double enable) : base(deviceId) {
+                    Enable = enable;
+                }
+            }
+
+            [JsonProperty("data")]
+            public Enable5VWithValueRequestData Data { get; set; }
+
+            public Enable5VWithValueRequest(string deviceId, double value) : base("arc_enable_5v") {
+                Data = new Enable5VWithValueRequestData(deviceId, value);
+            }
+        }
+
         private class EnableExpPortRequest : Request {
             [JsonProperty("data")]
             public EnableRequestData Data { get; set; }


### PR DESCRIPTION
This pull request enables setting the expansion port supply voltage for Ace Pro devices by adding an overload to Arc.Enable5V that accepts a voltage double parameter.